### PR TITLE
fix incplete type of QVector

### DIFF
--- a/RevisionsCache.h
+++ b/RevisionsCache.h
@@ -25,6 +25,7 @@
 
 #include <QObject>
 #include <QHash>
+#include <QVector>
 #include <QSharedPointer>
 
 class Git;

--- a/git.h
+++ b/git.h
@@ -9,6 +9,7 @@
 
 #include <QObject>
 #include <QVariant>
+#include <QVector>
 #include <QSharedPointer>
 
 template<class, class>


### PR DESCRIPTION
Fix following error.

  In file included from AGitProcess.cpp:3:
  git.h:232:20: Error：field 「rfDirs」 has incomplete type 「QVector<int>」
    232 |       QVector<int> rfDirs;
        |                    ^~~~~~

  In file included from RevisionsCache.cpp:1:
  RevisionsCache.h:63:21: Error：field 「revOrder」 has incomplete type 「QVector<QString>」
     63 |    QVector<QString> revOrder;
        |

Signed-off-by: Yen-Chin Lee <coldnew.tw@gmail.com>