### PR TITLE
Be able to override the prefix

### DIFF
--- a/GitQlient.pro
+++ b/GitQlient.pro
@@ -12,7 +12,7 @@ QMAKE_LFLAGS += -no-pie
 
 isEmpty(PREFIX):PREFIX = /usr/local
 
-target.path = $$PREFIX/bin/
+target.path = $$PREFIX/bin
 INSTALLS += target
 
 #project files

--- a/GitQlient.pro
+++ b/GitQlient.pro
@@ -10,10 +10,10 @@ QT += widgets core network svg
 DEFINES += QT_DEPRECATED_WARNINGS
 QMAKE_LFLAGS += -no-pie
 
-#Default rules for deployment.
-qnx: target.path = $$(HOME)/$${TARGET}/bin
-else: unix:!android: target.path = /$$(HOME)/$${TARGET}/bin
-!isEmpty(target.path): INSTALLS += target
+isEmpty(PREFIX):PREFIX = /usr/local
+
+target.path = $$PREFIX/bin/
+INSTALLS += target
 
 #project files
 SOURCES += src/main.cpp

--- a/GitQlient.pro
+++ b/GitQlient.pro
@@ -10,9 +10,14 @@ QT += widgets core network svg
 DEFINES += QT_DEPRECATED_WARNINGS
 QMAKE_LFLAGS += -no-pie
 
-isEmpty(PREFIX):PREFIX = /usr/local
+unix {
+   isEmpty(PREFIX) {
+      PREFIX = /usr/local
+   }
 
-target.path = $$PREFIX/bin
+   target.path = $$PREFIX/bin
+}
+
 INSTALLS += target
 
 #project files

--- a/contrib/rpm/gitqlient.spec
+++ b/contrib/rpm/gitqlient.spec
@@ -27,18 +27,20 @@ BuildRequires: desktop-file-utils
 %build
 %if 0%{?suse_version}
 #https://en.opensuse.org/openSUSE:Build_system_recipes#qmake
-qmake-qt5 -makefile QMAKE_CFLAGS+="%optflags" QMAKE_CXXFLAGS+="%optflags" QMAKE_STRIP="/bin/true" GitQlient.pro
+qmake-qt5 -makefile \
+   QMAKE_CFLAGS+="%optflags" \
+   QMAKE_CXXFLAGS+="%optflags" \
+   QMAKE_STRIP="/bin/true" \
+   PREFIX=%{_prefix}
+   GitQlient.pro
 %else
-%qmake_qt5 GitQlient.pro
+%qmake_qt5 PREFIX=%{_prefix} GitQlient.pro
 %endif
 
 %make_build
 
 %install
-
-#installs files into the user home directory by default
-#%make_install
-install -D -p -m755 GitQlient %{buildroot}%{_bindir}/GitQlient
+make install INSTALL_ROOT=%{buildroot}
 
 desktop-file-install                                    \
 --dir=%{buildroot}%{_datadir}/applications              \

--- a/contrib/rpm/gitqlient.spec
+++ b/contrib/rpm/gitqlient.spec
@@ -31,7 +31,7 @@ qmake-qt5 -makefile \
    QMAKE_CFLAGS+="%optflags" \
    QMAKE_CXXFLAGS+="%optflags" \
    QMAKE_STRIP="/bin/true" \
-   PREFIX=%{_prefix}
+   PREFIX=%{_prefix} \
    GitQlient.pro
 %else
 %qmake_qt5 PREFIX=%{_prefix} GitQlient.pro


### PR DESCRIPTION
Use the same setup as OpenSCAD [1]. The deployment (`make install`) for all supported platforms needs to be adjusted. Non of the ci-scripts uses `make install`

Fixes #151 

```
$ qmake-qt5 ... PREFIX=/usr
$ make
$ make install INSTALL_ROOT=/tmp/test
$ tree /tmp/test/
/tmp/test/
└── usr
    └── bin
        └── GitQlient

```

[1] https://github.com/openscad/openscad/blob/master/openscad.pro