### PR TITLE
Include icons and desktop file in install 

### DIFF
--- a/GitQlient.pro
+++ b/GitQlient.pro
@@ -16,6 +16,11 @@ unix {
    }
 
    target.path = $$PREFIX/bin
+
+   application.path = $$PREFIX/share/applications
+   application.files = AppImage/gitqlient/usr/share/applications/gitqlient.desktop
+
+   INSTALLS += application
 }
 
 INSTALLS += target

--- a/GitQlient.pro
+++ b/GitQlient.pro
@@ -19,8 +19,29 @@ unix {
 
    application.path = $$PREFIX/share/applications
    application.files = AppImage/gitqlient/usr/share/applications/gitqlient.desktop
-
    INSTALLS += application
+
+   iconsvg.path = $$PREFIX/share/icons/hicolor/scalable/apps
+   iconsvg.extra = \$(QINSTALL) src/resources/icons/GitQlientLogo.svg \$(INSTALL_ROOT)$${iconsvg.path}/$${TARGET}.svg
+   icon16.path = $$PREFIX/share/icons/hicolor/16x16/apps
+   icon16.extra = \$(QINSTALL) src/resources/icons/GitQlientLogo16.png \$(INSTALL_ROOT)$${icon16.path}/$${TARGET}.png
+   icon24.path = $$PREFIX/share/icons/hicolor/24x24/apps
+   icon24.extra = \$(QINSTALL) src/resources/icons/GitQlientLogo24.png \$(INSTALL_ROOT)$${icon24.path}/$${TARGET}.png
+   icon32.path = $$PREFIX/share/icons/hicolor/32x32/apps
+   icon32.extra = \$(QINSTALL) src/resources/icons/GitQlientLogo32.png \$(INSTALL_ROOT)$${icon32.path}/$${TARGET}.png
+   icon48.path = $$PREFIX/share/icons/hicolor/48x48/apps
+   icon48.extra = \$(QINSTALL) src/resources/icons/GitQlientLogo48.png \$(INSTALL_ROOT)$${icon48.path}/$${TARGET}.png
+   icon64.path = $$PREFIX/share/icons/hicolor/64x64/apps
+   icon64.extra = \$(QINSTALL) src/resources/icons/GitQlientLogo64.png \$(INSTALL_ROOT)$${icon64.path}/$${TARGET}.png
+   icon96.path = $$PREFIX/share/icons/hicolor/96x96/apps
+   icon96.extra = \$(QINSTALL) src/resources/icons/GitQlientLogo96.png \$(INSTALL_ROOT)$${icon96.path}/$${TARGET}.png
+   icon128.path = $$PREFIX/share/icons/hicolor/128x128/apps
+   icon128.extra = \$(QINSTALL) src/resources/icons/GitQlientLogo128.png \$(INSTALL_ROOT)$${icon128.path}/$${TARGET}.png
+   icon256.path = $$PREFIX/share/icons/hicolor/256x256/apps
+   icon256.extra = \$(QINSTALL) src/resources/icons/GitQlientLogo256.png \$(INSTALL_ROOT)$${icon256.path}/$${TARGET}.png
+   icon512.path = $$PREFIX/share/icons/hicolor/512x512/apps
+   icon512.extra = \$(QINSTALL) src/resources/icons/GitQlientLogo512.png \$(INSTALL_ROOT)$${icon512.path}/$${TARGET}.png
+   INSTALLS += iconsvg icon16 icon24 icon32 icon48 icon64 icon96 icon128 icon256 icon512
 }
 
 INSTALLS += target

--- a/contrib/rpm/gitqlient.spec
+++ b/contrib/rpm/gitqlient.spec
@@ -45,13 +45,13 @@ make install INSTALL_ROOT=%{buildroot}
 desktop-file-validate %{buildroot}%{_datadir}/applications/gitqlient.desktop
 
 install -dD %{buildroot}%{_datadir}/icons
-cp -a AppImage/GitQlient/usr/share/icons/* %{buildroot}%{_datadir}/icons/
+cp -a AppImage/gitqlient/usr/share/icons/* %{buildroot}%{_datadir}/icons/
 
 %files
 %doc README.md
 %license LICENSE
-%{_bindir}/GitQlient
-%{_datadir}/applications/GitQlient.desktop
+%{_bindir}/gitqlient
+%{_datadir}/applications/gitqlient.desktop
 %{_datadir}/icons
 
 %changelog

--- a/contrib/rpm/gitqlient.spec
+++ b/contrib/rpm/gitqlient.spec
@@ -44,15 +44,12 @@ make install INSTALL_ROOT=%{buildroot}
 
 desktop-file-validate %{buildroot}%{_datadir}/applications/gitqlient.desktop
 
-install -dD %{buildroot}%{_datadir}/icons
-cp -a AppImage/gitqlient/usr/share/icons/* %{buildroot}%{_datadir}/icons/
-
 %files
 %doc README.md
 %license LICENSE
 %{_bindir}/gitqlient
-%{_datadir}/applications/gitqlient.desktop
-%{_datadir}/icons
+%{_datadir}/applications/%{name}.desktop
+%{_datadir}/icons/hicolor/*/apps/%{name}.*
 
 %changelog
 {{{ git_changelog }}}

--- a/contrib/rpm/gitqlient.spec
+++ b/contrib/rpm/gitqlient.spec
@@ -42,9 +42,7 @@ qmake-qt5 -makefile \
 %install
 make install INSTALL_ROOT=%{buildroot}
 
-desktop-file-install                                    \
---dir=%{buildroot}%{_datadir}/applications              \
-AppImage/GitQlient/usr/share/applications/GitQlient.desktop
+desktop-file-validate %{buildroot}%{_datadir}/applications/gitqlient.desktop
 
 install -dD %{buildroot}%{_datadir}/icons
 cp -a AppImage/GitQlient/usr/share/icons/* %{buildroot}%{_datadir}/icons/

--- a/contrib/rpm/gitqlient.spec
+++ b/contrib/rpm/gitqlient.spec
@@ -42,7 +42,7 @@ qmake-qt5 -makefile \
 %install
 make install INSTALL_ROOT=%{buildroot}
 
-desktop-file-validate %{buildroot}%{_datadir}/applications/gitqlient.desktop
+desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 
 %files
 %doc README.md


### PR DESCRIPTION
Include icons and desktop file as part of the `make install` command.

The RPM spec file is updated to reflect this change. As a bonus, the entire `AppImage` root folder can be removed from git and reproduced by during building of AppImage like this (not tested):

```
diff --git a/ci-scripts/linux/build.sh b/ci-scripts/linux/build.sh
index c3e5d23..dc1cc34 100755
--- a/ci-scripts/linux/build.sh
+++ b/ci-scripts/linux/build.sh
@@ -7,10 +7,9 @@ mkdir build
 cd build
 g++ --version
 qmake --version
-$QTDIR/bin/qmake ../GitQlient.pro
+$QTDIR/bin/qmake PREFIX=/usr ../GitQlient.pro
 make -j 4
-mkdir -p ../AppImage/gitqlient/usr/bin
-cp gitqlient ../AppImage/gitqlient/usr/bin
+make install INSTALL_ROOT=../AppImage
 cd ../AppImage
 wget -q -O linuxdeployqt https://github.com/probonopd/linuxdeployqt/releases/download/6/linuxdeployqt-6-x86_64.AppImage
 chmod +x linuxdeployqt
```

Build info: https://copr.fedorainfracloud.org/coprs/jonny/Qt/build/1689630/

Fixes #152 