### PR TITLE
Remove unused "styles" variable in GitQlient's constructor

### DIFF
--- a/src/big_widgets/GitQlient.cpp
+++ b/src/big_widgets/GitQlient.cpp
@@ -36,8 +36,6 @@ GitQlient::GitQlient(const QStringList &arguments, QWidget *parent)
    QLog_Info("UI", QString("*                  %1                  *").arg(VER));
    QLog_Info("UI", "*******************************************");
 
-   QFile styles(":/stylesheet");
-
    setStyleSheet(GitQlientStyles::getStyles());
 
    const auto addTab = new QPushButton();


### PR DESCRIPTION
<!-- Please, before creating the Pull Request ensure that your code is formatted following the clang-format file in the repo. Make sure that the code compiles and you've tested in any way. -->

<!-- Once the Pull Request is open, please mark the checkbox regarding the change type you are submitting. -->

## Description
<!--- Provide a short description of what has been changed and which area does it affect --->
This variable inside GitQlient's constructor is forgotten: `QFile styles(":/stylesheet");`

## Change Type

- [ ] Bugfix
- [ ] Feature
- [X] Improvement

## Reason
<!--- Provide a reason why this change was made.--->
Getting rid of an unused and therefore unnecessary variable.

## Related Issue
<!--- Is this Pull Request related with an existing issue on GitQlient? If so, please provide the number starting with # (e.g. #20). --->

## Tests
<!--- How have you tested your change? --->
