### PR TITLE
Open repo fix

### DIFF
--- a/src/big_widgets/GitQlient.cpp
+++ b/src/big_widgets/GitQlient.cpp
@@ -6,6 +6,7 @@
 #include <QPinnableTabWidget.h>
 #include <InitialRepoConfig.h>
 
+#include <QCommandLineParser>
 #include <QProcess>
 #include <QTabBar>
 #include <GitQlientRepo.h>
@@ -14,6 +15,7 @@
 #include <QFile>
 #include <QFileDialog>
 #include <QMessageBox>
+#include <QTextStream>
 #include <GitBase.h>
 
 #include <QLogger.h>
@@ -21,18 +23,10 @@
 using namespace QLogger;
 
 GitQlient::GitQlient(QWidget *parent)
-   : GitQlient(QStringList(), parent)
-{
-}
-
-GitQlient::GitQlient(const QStringList &arguments, QWidget *parent)
    : QWidget(parent)
    , mRepos(new QPinnableTabWidget())
    , mConfigWidget(new InitScreen())
 {
-
-   auto repos = parseArguments(arguments);
-
    QLog_Info("UI", "*******************************************");
    QLog_Info("UI", "*          GitQlient has started          *");
    QLog_Info("UI", QString("*                  %1                  *").arg(VER));
@@ -59,8 +53,6 @@ GitQlient::GitQlient(const QStringList &arguments, QWidget *parent)
    mConfigWidget->onRepoOpened();
 
    connect(mConfigWidget, &InitScreen::signalOpenRepo, this, &GitQlient::addRepoTab);
-
-   setRepositories(repos);
 
    GitQlientSettings settings;
    const auto geometry = settings.globalValue("GitQlientGeometry", saveGeometry()).toByteArray();
@@ -110,67 +102,82 @@ void GitQlient::setRepositories(const QStringList &repositories)
       addRepoTab(repo);
 }
 
-void GitQlient::setArgumentsPostInit(const QStringList &arguments)
+bool GitQlient::setArgumentsPostInit(const QStringList &arguments)
 {
    QLog_Info("UI", QString("External call with the params {%1}").arg(arguments.join(",")));
 
-   const auto repos = parseArguments(arguments);
-
-   setRepositories(repos);
+   QStringList repos;
+   bool ret = parseArguments(arguments, &repos);
+   if (ret) {
+      setRepositories(repos);
+   }
+   return ret;
 }
 
-QStringList GitQlient::parseArguments(const QStringList &arguments)
+bool GitQlient::parseArguments(const QStringList &arguments, QStringList *repos)
 {
-
-   LogLevel logLevel;
+   bool ret = true;
    GitQlientSettings settings;
-
 #ifdef DEBUG
-   logLevel = LogLevel::Trace;
+   LogLevel logLevel = LogLevel::Trace;
 #else
-   logLevel = static_cast<LogLevel>(settings.globalValue("logsLevel", static_cast<int>(LogLevel::Warning)).toInt());
+   LogLevel logLevel = static_cast<LogLevel>(settings.globalValue("logsLevel", static_cast<int>(LogLevel::Warning)).toInt());
 #endif
+   bool areLogsDisabled = settings.globalValue("logsDisabled", true).toBool();
 
-   if (arguments.contains("-noLog") || settings.globalValue("logsDisabled", true).toBool())
-      QLoggerManager::getInstance()->pause();
-   else
-      QLoggerManager::getInstance()->overwriteLogLevel(logLevel);
+   QCommandLineParser parser;
+   parser.setApplicationDescription(tr("Graphical Git client"));
+   parser.addPositionalArgument("repos", tr("Git repositories to open"), tr("[repos...]"));
 
-   QLog_Info("UI", QString("Getting arguments {%1}").arg(arguments.join(", ")));
+   const QCommandLineOption helpOption = parser.addHelpOption();
+   // We don't use parser.addVersionOption() because then it is handled by Qt and we want to show Git SHA also
+   const QCommandLineOption versionOption(QStringList() << "v" << "version", tr("Displays version information."));
+   parser.addOption(versionOption);
 
-   QStringList repos;
-   const auto argSize = arguments.count();
+   const QCommandLineOption noLogOption("no-log", tr("Disables logs."));
+   parser.addOption(noLogOption);
 
-   for (auto i = 0; i < argSize;)
+   const QCommandLineOption logLevelOption("log-level", tr("Sets log level."), tr("level"));
+   parser.addOption(logLevelOption);
+
+   parser.process(arguments);
+
+   *repos = parser.positionalArguments();
+   if (parser.isSet(noLogOption))
+      areLogsDisabled = true;
+
+   if (!areLogsDisabled)
    {
-      if (arguments.at(i) == "-repos")
+      if (parser.isSet(logLevelOption))
       {
-         while (++i < argSize && !arguments.at(i).startsWith("-"))
-            repos.append(arguments.at(i));
-      }
-      else
-      {
-         if (arguments.at(i) == "-logLevel")
+         LogLevel level = static_cast<LogLevel>(parser.value(logLevelOption).toInt());
+         if (level >= QLogger::LogLevel::Trace && level <= QLogger::LogLevel::Fatal)
          {
-            logLevel = static_cast<LogLevel>(arguments.at(++i).toInt());
-
-            if (logLevel >= QLogger::LogLevel::Trace && logLevel <= QLogger::LogLevel::Fatal)
-            {
-               const auto logger = QLoggerManager::getInstance();
-               logger->overwriteLogLevel(logLevel);
-
-               settings.setGlobalValue("logsLevel", static_cast<int>(logLevel));
-            }
+            logLevel = level;
+            settings.setGlobalValue("logsLevel", static_cast<int>(level));
          }
-
-         ++i;
       }
+
+      QLoggerManager::getInstance()->overwriteLogLevel(logLevel);
+      QLog_Info("UI", QString("Getting arguments {%1}").arg(arguments.join(", ")));
    }
+   else
+      QLoggerManager::getInstance()->pause();
+
+   if (parser.isSet(versionOption))
+   {
+      QTextStream out(stdout);
+      out << QCoreApplication::applicationName() << ' ' << tr("version") << ' ' << QCoreApplication::applicationVersion()
+          << " (" << tr("Git SHA ") << SHA_VER << ")\n";
+      ret = false;
+   }
+   if (parser.isSet(helpOption))
+      ret = false;
 
    const auto manager = QLoggerManager::getInstance();
    manager->addDestination("GitQlient.log", { "UI", "Git", "Cache" }, logLevel);
 
-   return repos;
+   return ret;
 }
 
 void GitQlient::addRepoTab(const QString &repoPath)

--- a/src/big_widgets/GitQlient.cpp
+++ b/src/big_widgets/GitQlient.cpp
@@ -185,8 +185,10 @@ void GitQlient::addRepoTab(const QString &repoPath)
    addNewRepoTab(repoPath, false);
 }
 
-void GitQlient::addNewRepoTab(const QString &repoPath, bool pinned)
+void GitQlient::addNewRepoTab(const QString &repoPathArg, bool pinned)
 {
+   const QString repoPath = QFileInfo(repoPathArg).canonicalFilePath();
+
    if (!mCurrentRepos.contains(repoPath))
    {
       QFileInfo info(QString("%1/.git").arg(repoPath));

--- a/src/big_widgets/GitQlient.h
+++ b/src/big_widgets/GitQlient.h
@@ -48,13 +48,7 @@ public:
     \param parent The parent widget if needed.
    */
    explicit GitQlient(QWidget *parent = nullptr);
-   /*!
-    \brief Overloaded constructor. Takes a list of arguments and after parsing them, starts the GitQlient instance.
 
-    \param arguments Command prompt arguments.
-    \param parent The parent wiget if needed.
-   */
-   explicit GitQlient(const QStringList &arguments, QWidget *parent = nullptr);
    /*!
     \brief Destructor.
 
@@ -71,8 +65,9 @@ public:
     \brief In case that the GitQlient instance it's already initialize, the user can add arguments to be processed.
 
     \param arguments The list of arguments.
+    \return Returns true if application should continue or false if it should quit.
    */
-   void setArgumentsPostInit(const QStringList &arguments);
+   bool setArgumentsPostInit(const QStringList &arguments);
 
    /**
     * @brief restorePinnedRepos This method restores the pinned repos from the last session
@@ -80,19 +75,21 @@ public:
     */
    void restorePinnedRepos();
 
+   /*!
+    \brief This method parses all the arguments and configures GitQlient settings with them. Part of the arguments can
+    be a list of repositories to be opened. In that case, the method returns the list of repositories to open in the repos out parameter.
+
+    \param arguments Arguments from the command prompt.
+    \param repos Output paramter, repositories to open.
+    \return Returns true if application should continue or false if it should quit.
+   */
+   static bool parseArguments(const QStringList &arguments, QStringList *repos);
+
 private:
    QPinnableTabWidget *mRepos = nullptr;
    InitScreen *mConfigWidget = nullptr;
    QSet<QString> mCurrentRepos;
 
-   /*!
-    \brief This method parses all the arguments and configures GitQlient settings with them. Part of the arguments can
-    be a list of repositories to be opened. In that case, the method returns the list of repositories to open.
-
-    \param arguments Arguments from the command prompt.
-    \return QStringList Returns the list of repositories to be opened. Empty if none is passed.
-   */
-   QStringList parseArguments(const QStringList &arguments);
    /*!
     \brief Opens a QFileDialog to select a repository in the local disk.
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,7 @@ int main(int argc, char *argv[])
    QApplication::setOrganizationName("CescSoftware");
    QApplication::setOrganizationDomain("francescmm.com");
    QApplication::setApplicationName("GitQlient");
+   QApplication::setApplicationVersion(VER);
    QApplication::setWindowIcon(QIcon(":/icons/GitQlientLogoIco"));
 
    QFontDatabase::addApplicationFont(":/DejaVuSans");
@@ -33,13 +34,16 @@ int main(int argc, char *argv[])
    GitQlientSettings settings;
    settings.setGlobalValue("isGitQlient", true);
 
-   GitQlient mainWin(arguments);
+   QStringList repos;
+   if (GitQlient::parseArguments(arguments, &repos))
+   {
+      GitQlient mainWin;
+      mainWin.setRepositories(repos);
+      mainWin.show();
 
-   mainWin.show();
+      QTimer::singleShot(500, &mainWin, &GitQlient::restorePinnedRepos);
 
-   QTimer::singleShot(500, &mainWin, &GitQlient::restorePinnedRepos);
-
-   const auto ret = app.exec();
-
-   return ret;
+      return app.exec();
+   } else
+      return 0;
 }


### PR DESCRIPTION
## Description
When opening a repo the app doesn't use canonical paths, so if I call it like this: gitqlient -repos ~/myrepo /home/user/myrepo .
It will open myrepo twice and also won't be able to open current directory (.)

## Change Type

- [x] Bugfix
- [ ] Feature
- [ ] Improvement

## Reason
Proper path handling is an essential functionality.

## Related Issue
None

## Tests
Manual.
