### PR TITLE
When opening a repo use canonical path

### DIFF
--- a/src/big_widgets/GitQlient.cpp
+++ b/src/big_widgets/GitQlient.cpp
@@ -178,8 +178,10 @@ void GitQlient::addRepoTab(const QString &repoPath)
    addNewRepoTab(repoPath, false);
 }
 
-void GitQlient::addNewRepoTab(const QString &repoPath, bool pinned)
+void GitQlient::addNewRepoTab(const QString &repoPathArg, bool pinned)
 {
+   const QString repoPath = QFileInfo(repoPathArg).canonicalFilePath();
+
    if (!mCurrentRepos.contains(repoPath))
    {
       QFileInfo info(QString("%1/.git").arg(repoPath));


### PR DESCRIPTION
## Description
When opening a repo the app doesn't use canonical paths, so if I call it like this: gitqlient -repos myrepo /home/user/myrepo .
It will open myrepo twice and also won't be able to open current directory (.)

## Change Type

- [x] Bugfix
- [ ] Feature
- [ ] Improvement

## Reason
Proper path handling is essential functionality.

## Related Issue
None

## Tests
Manual.
