### PR TITLE
Don't build with -Werror by default

### DIFF
--- a/GitQlient.pro
+++ b/GitQlient.pro
@@ -1,10 +1,6 @@
 #General stuff
 CONFIG += qt warn_on c++ 17 c++1z
 
-greaterThan(QT_MINOR_VERSION, 12) {
-!msvc:QMAKE_CXXFLAGS += -Werror
-}
-
 TARGET = gitqlient
 QT += widgets core network webenginewidgets webchannel
 DEFINES += QT_DEPRECATED_WARNINGS


### PR DESCRIPTION
<!-- Please, before creating the Pull Request ensure that your code is formatted following the clang-format file in the repo. Make sure that the code compiles and you've tested in any way. -->

<!-- Once the Pull Request is open, please mark the checkbox regarding the change type you are submitting. -->

## Description
<!--- Provide a short description of what has been changed and which area does it affect --->
Remove ``-Werror`` from the specified compiler flags.

## Change Type

- [x] Bugfix
- [ ] Feature
- [ ] Improvement

## Reason
New versions of gcc and clang always introduce new warnings, so enabling ``-Werror`` by default virtually guarantees that the build will end up broken for users at some point, as it currently is for me:
```
cc1plus: all warnings being treated as errors
make: *** [Makefile:3172: UnstagedMenu.o] Error 1
make: *** Waiting for unfinished jobs....
In file included from /usr/include/qt/QtCore/qstring.h:2168,
                 from /usr/include/qt/QtCore/qhashfunctions.h:44,
                 from /usr/include/qt/QtCore/qvector.h:47,
                 from /usr/include/qt/QtCore/QVector:1,
                 from src/cache/CommitInfo.h:26,
                 from src/git/GitRepoLoader.h:26,
                 from src/git/GitRepoLoader.cpp:1:
In static member function ‘static void QConcatenable<QByteArray>::appendTo(const QByteArray&, char*&)’,
    inlined from ‘static void QConcatenable<QStringBuilder<A, B> >::appendTo(const type&, T*&) [with T = char; A = QByteArray; B = char]’ at /usr/include/qt/QtCore/qstringbuilder.h:428:35,
    inlined from ‘T QStringBuilder<A, B>::convertTo() const [with T = QByteArray; A = QByteArray; B = char]’ at /usr/include/qt/QtCore/qstringbuilder.h:118:56,
    inlined from ‘QStringBuilder<A, B>::operator QStringBuilder<A, B>::ConvertTo() const [with A = QByteArray; B = char ’ at /usr/include/qt/QtCore/qstringbuilder.h:131:62,
    inlined from ‘QList<CommitInfo> GitRepoLoader::processSignedLog(QByteArray&, QList<QPair<QString, QString> >&) cons ’ at src/git/GitRepoLoader.cpp:304:23:
/usr/include/qt/QtCore/qstringbuilder.h:411:20: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
  411 |             *out++ = *a++;
      |             ~~~~~~~^~~~~~
/usr/include/qt/QtCore/qstringbuilder.h:411:20: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
/usr/include/qt/QtCore/qstringbuilder.h:411:20: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
/usr/include/qt/QtCore/qstringbuilder.h:411:20: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
/usr/include/qt/QtCore/qstringbuilder.h:411:20: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
/usr/include/qt/QtCore/qstringbuilder.h:411:20: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
/usr/include/qt/QtCore/qstringbuilder.h:411:20: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
```
(NB: I'm using gcc version 11.1.0.)

Developers should always fix all compiler warnings and the CI should check for it, but it's always a bad idea to turn (likely) harmless warnings into fatal errors by default.
## Related Issue
<!--- Is this Pull Request related with an existing issue on GitQlient? If so, please provide the number starting with # (e.g. #20). --->

## Tests
<!--- How have you tested your change? --->
