### PR TITLE
Use high DPI pixmaps

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,7 +10,10 @@ using namespace QLogger;
 
 int main(int argc, char *argv[])
 {
-   qputenv("QT_AUTO_SCREEN_SCALE_FACTOR", "1");
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+   QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+   QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
 
    QApplication app(argc, argv);
 


### PR DESCRIPTION
<!-- Please, before creating the Pull Request ensure that your code is formatted following the clang-format file in the repo. Make sure that the code compiles and you've tested in any way. -->

<!-- Once the Pull Request is open, please mark the checkbox regarding the change type you are submitting. -->

## Description
Fixes pixelated icons on high DPI displays. The below image shows icons before and after this change (125% DPI).
![gitqlient-high-dpi-pixmaps](https://user-images.githubusercontent.com/78597079/171881171-0b0bccf9-a17f-48e9-8dfa-b6dae60be208.png)


## Change Type

- [x] Bugfix
- [ ] Feature
- [ ] Improvement

## Reason
<!--- Provide a reason why this change was made.--->

## Related Issue
#246 

## Tests
<!--- How have you tested your change? --->
