### PR TITLE
Add an single click option in the unstaged/staged file list to open the diff view

### DIFF
--- a/src/big_widgets/ConfigWidget.cpp
+++ b/src/big_widgets/ConfigWidget.cpp
@@ -107,6 +107,7 @@ ConfigWidget::ConfigWidget(const QSharedPointer<GitBase> &git, QWidget *parent)
    ui->cbLogLevel->setCurrentIndex(settings.globalValue("logsLevel", static_cast<int>(LogLevel::Warning)).toInt());
    ui->spCommitTitleLength->setValue(settings.globalValue("commitTitleMaxLength", 50).toInt());
    ui->sbEditorFontSize->setValue(settings.globalValue("FileDiffView/FontSize", 8).toInt());
+   ui->chSingleClickDiffView->setChecked(settings.globalValue("singleClickDiffView", false).toBool());
 
 #ifdef Q_OS_LINUX
    ui->leEditor->setText(settings.globalValue("ExternalEditor", QString()).toString());
@@ -204,6 +205,7 @@ ConfigWidget::ConfigWidget(const QSharedPointer<GitBase> &git, QWidget *parent)
    connect(mPluginsDownloader, &PluginsDownloader::availablePlugins, this, &ConfigWidget::onPluginsInfoReceived);
    connect(mPluginsDownloader, &PluginsDownloader::pluginStored, this, &ConfigWidget::onPluginStored);
    connect(ui->pbFeaturesTour, &QPushButton::clicked, this, &ConfigWidget::showFeaturesTour);
+   connect(ui->chSingleClickDiffView, &CheckBox::stateChanged, this, &ConfigWidget::saveConfig);
 
    auto size = calculateDirSize(ui->leLogsLocation->text());
    ui->lLogsSize->setText(QString("%1 KB").arg(size));
@@ -363,6 +365,7 @@ void ConfigWidget::saveConfig()
    settings.setGlobalValue("FileDiffView/FontSize", ui->sbEditorFontSize->value());
    settings.setGlobalValue("colorSchema", ui->cbStyle->currentText());
    settings.setGlobalValue("gitLocation", ui->leGitPath->text());
+   settings.setGlobalValue("singleClickDiffView", ui->chSingleClickDiffView->isChecked());
 
    if (!ui->leEditor->text().isEmpty())
       settings.setGlobalValue("ExternalEditor", ui->leEditor->text());

--- a/src/big_widgets/ConfigWidget.ui
+++ b/src/big_widgets/ConfigWidget.ui
@@ -391,6 +391,29 @@
            </layout>
           </item>
           <item>
+           <widget class="QGroupBox" name="groupBox_4">
+            <property name="title">
+             <string>General</string>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_2">
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_34">
+               <property name="text">
+                <string>Single click to open diff view </string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="CheckBox" name="chSingleClickDiffView">
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
            <spacer name="verticalSpacer_2">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -445,8 +468,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>551</width>
-            <height>778</height>
+            <width>475</width>
+            <height>712</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_2">

--- a/src/big_widgets/ConfigWidget.ui
+++ b/src/big_widgets/ConfigWidget.ui
@@ -399,7 +399,7 @@
              <item row="0" column="0">
               <widget class="QLabel" name="label_34">
                <property name="text">
-                <string>Single click to open diff view </string>
+                <string>Single click on file to open diff view (needs restart) </string>
                </property>
               </widget>
              </item>

--- a/src/commits/CommitChangesWidget.cpp
+++ b/src/commits/CommitChangesWidget.cpp
@@ -56,6 +56,7 @@ CommitChangesWidget::CommitChangesWidget(const QSharedPointer<GitCache> &cache, 
    ui->amendFrame->setVisible(false);
 
    mTitleMaxLength = GitQlientSettings().globalValue("commitTitleMaxLength", mTitleMaxLength).toInt();
+   bool singleClick = GitQlientSettings().globalValue("singleClickDiffView", false).toBool();
 
    ui->lCounter->setText(QString::number(mTitleMaxLength));
    ui->leCommitTitle->setMaxLength(mTitleMaxLength);
@@ -70,8 +71,17 @@ CommitChangesWidget::CommitChangesWidget(const QSharedPointer<GitCache> &cache, 
            [this](const QString &fileName) { requestDiff(mGit->getWorkingDir() + "/" + fileName); });
    connect(ui->unstagedFilesList, &QListWidget::customContextMenuRequested, this,
            &CommitChangesWidget::showUnstagedMenu);
-   connect(ui->unstagedFilesList, &QListWidget::itemDoubleClicked, this,
-           [this](QListWidgetItem *item) { requestDiff(mGit->getWorkingDir() + "/" + item->toolTip()); });
+
+   if (singleClick)
+   {
+       connect(ui->unstagedFilesList, &QListWidget::itemClicked, this,
+               [this](QListWidgetItem *item) { requestDiff(mGit->getWorkingDir() + "/" + item->toolTip()); });
+   }
+   else
+   {
+       connect(ui->unstagedFilesList, &QListWidget::itemDoubleClicked, this,
+               [this](QListWidgetItem *item) { requestDiff(mGit->getWorkingDir() + "/" + item->toolTip()); });
+   }
 
    ui->warningButton->setVisible(false);
    ui->applyActionBtn->setText(tr("Commit"));

--- a/src/commits/CommitChangesWidget.cpp
+++ b/src/commits/CommitChangesWidget.cpp
@@ -72,16 +72,8 @@ CommitChangesWidget::CommitChangesWidget(const QSharedPointer<GitCache> &cache, 
    connect(ui->unstagedFilesList, &QListWidget::customContextMenuRequested, this,
            &CommitChangesWidget::showUnstagedMenu);
 
-   if (singleClick)
-   {
-       connect(ui->unstagedFilesList, &QListWidget::itemClicked, this,
-               [this](QListWidgetItem *item) { requestDiff(mGit->getWorkingDir() + "/" + item->toolTip()); });
-   }
-   else
-   {
-       connect(ui->unstagedFilesList, &QListWidget::itemDoubleClicked, this,
-               [this](QListWidgetItem *item) { requestDiff(mGit->getWorkingDir() + "/" + item->toolTip()); });
-   }
+   connect(ui->unstagedFilesList, singleClick ? &QListWidget::itemClicked : &QListWidget::itemDoubleClicked, this,
+           [this](QListWidgetItem *item) { requestDiff(mGit->getWorkingDir() + "/" + item->toolTip()); });
 
    ui->warningButton->setVisible(false);
    ui->applyActionBtn->setText(tr("Commit"));

--- a/src/commits/StagedFilesList.cpp
+++ b/src/commits/StagedFilesList.cpp
@@ -13,14 +13,7 @@ StagedFilesList::StagedFilesList(QWidget *parent)
 
    bool singleClick = GitQlientSettings().globalValue("singleClickDiffView", false).toBool();
 
-   if (singleClick)
-   {
-        connect(this, &QListWidget::itemClicked, this, &StagedFilesList::onDoubleClick);
-   }
-   else
-   {
-        connect(this, &QListWidget::itemDoubleClicked, this, &StagedFilesList::onDoubleClick);
-   }
+   connect(this, singleClick ? &QListWidget::itemClicked : &QListWidget::itemDoubleClicked, this, &StagedFilesList::onDoubleClick);
 }
 
 void StagedFilesList::onContextMenu(const QPoint &pos)

--- a/src/commits/StagedFilesList.cpp
+++ b/src/commits/StagedFilesList.cpp
@@ -1,14 +1,26 @@
 #include "StagedFilesList.h"
 
+#include <GitQlientSettings.h>
 #include <GitQlientRole.h>
 
 #include <QMenu>
 
 StagedFilesList::StagedFilesList(QWidget *parent)
    : QListWidget(parent)
+
 {
    connect(this, &QListWidget::customContextMenuRequested, this, &StagedFilesList::onContextMenu);
-   connect(this, &QListWidget::itemDoubleClicked, this, &StagedFilesList::onDoubleClick);
+
+   bool singleClick = GitQlientSettings().globalValue("singleClickDiffView", false).toBool();
+
+   if (singleClick)
+   {
+        connect(this, &QListWidget::itemClicked, this, &StagedFilesList::onDoubleClick);
+   }
+   else
+   {
+        connect(this, &QListWidget::itemDoubleClicked, this, &StagedFilesList::onDoubleClick);
+   }
 }
 
 void StagedFilesList::onContextMenu(const QPoint &pos)


### PR DESCRIPTION
## Description

Add a global option to enable a single click to open the unstaged/staged file diff view instead of double click (default behavior).

The default behavior has been kept for existing users.

## Change Type

- [ ] Bugfix
- [x] Feature
- [ ] Improvement

## Reason

While managing a lot of files and a lot of projects, a single click is quicker to easily look for changes before commit.

## Related Issue

N/A

## Tests

Enable/disable click. Current implementation needs a restart for the option to be applied (not sure if it is possible to dispatch changed configuration through widgets).

