### PR TITLE
Fix category in .desktop file

### DIFF
--- a/src/resources/gitqlient.desktop
+++ b/src/resources/gitqlient.desktop
@@ -4,4 +4,4 @@ Name=GitQlient
 Comment=A multi-platform Git client made with Qt
 Exec=gitqlient
 Icon=gitqlient
-Categories=Office;
+Categories=Development;


### PR DESCRIPTION
<!-- Please, before creating the Pull Request ensure that your code is formatted following the clang-format file in the repo. Make sure that the code compiles and you've tested in any way. -->

<!-- Once the Pull Request is open, please mark the checkbox regarding the change type you are submitting. -->

## Description
This makes sure that GitQlient ends up at the right in the "start menu" of the desktop environment.

## Change Type

- [x] Bugfix
- [ ] Feature
- [ ] Improvement

## Reason
- Was ending up in an unexpected folder in application start menu of the desktop environment, e.g. XFCE
- Was suggested by @band-a-prend at https://github.com/gentoo/guru/blob/0c250f9633324eb35160cb1906087e386f3e6411/dev-vcs/gitqlient/gitqlient-1.6.1.ebuild#L38

## Related Issue
n/a

## Tests
- Checked where it ends up in the XFCE start menu, in practice.
- Also validation:
```console
# desktop-file-validate src/resources/gitqlient.desktop ; echo $?
0
```
