### PR TITLE
GitQlient.pro: Improve distro packagability

### DIFF
--- a/GitQlient.pro
+++ b/GitQlient.pro
@@ -56,7 +56,8 @@ isEmpty(VERSION) {
 win32 {
    VERSION = 0.0.0
 } else {
-   VERSION = $$system(git rev-parse --short HEAD)
+   VERSION = $$system(git describe --abbrev=0)
+   VERSION = $$replace(VERSION, "v", "")
 }
 }
 

--- a/GitQlient.pro
+++ b/GitQlient.pro
@@ -61,7 +61,9 @@ win32 {
 }
 }
 
-GQ_SHA = $$system(git rev-parse --short HEAD)
+!defined(GQ_SHA, var) {
+   GQ_SHA = $$system(git rev-parse --short HEAD)
+}
 
 DEFINES += \
     VER=\\\"$$VERSION\\\" \

--- a/GitQlient.pro
+++ b/GitQlient.pro
@@ -69,6 +69,8 @@ DEFINES += \
     VER=\\\"$$VERSION\\\" \
     SHA_VER=\\\"$$GQ_SHA\\\"
 
+message("Found version \"$$VERSION\" at commit \"$$GQ_SHA\".")
+
 debug {
    DEFINES += DEBUG
 }


### PR DESCRIPTION
<!-- Please, before creating the Pull Request ensure that your code is formatted following the clang-format file in the repo. Make sure that the code compiles and you've tested in any way. -->

<!-- Once the Pull Request is open, please mark the checkbox regarding the change type you are submitting. -->

## Description
Three small related things for `GitQlient.pro`:
- Fix the extraction of `VERSION` to use Git tags
- Allow passing `GQ_SHA` from the outside for distro packaging
- Report on found values for `VERSION` and `GQ_SHA` to ease debugging

CC @band-a-prend

## Change Type

- [ ] Bugfix
- [ ] Feature
- [x] Improvement

## Reason
Distro packaging is based on source tarballs and they do not come with a `.git` folder, so packaging currently has to patch away invocation of Git, e.g. see https://github.com/gentoo/guru/blob/0c250f9633324eb35160cb1906087e386f3e6411/dev-vcs/gitqlient/gitqlient-1.6.1.ebuild#L35-L36

## Related Issue
n/a

## Tests
Add debug output and play with the two main cases:

```console
# qmake5 GitQlient.pro
[..]
Project MESSAGE: Found version "1.6.1" at commit "e604c6eb".

# qmake5 GitQlient.pro VERSION=1.2.3 GQ_SHA=4567
[..]
Project MESSAGE: Found version "1.2.3" at commit "4567".
```
