### PR TITLE
QMake: Detect and report missing Git submodules

### DIFF
--- a/src/App.pri
+++ b/src/App.pri
@@ -1,3 +1,15 @@
+submodule_check_files = \
+    $$PWD/AuxiliarCustomWidgets/AuxiliarCustomWidgets.pri \
+    $$PWD/QLogger/QLogger.pri \
+    $$PWD/QPinnableTabWidget/QPinnableTabWidget.pri \
+    $$PWD/git/Git.pri
+
+for(filename, submodule_check_files) {
+    !exists($${filename}) {
+        error("File \"$${filename}\" from a Git submodule could not be found, have you run \"git submodule update --init\" already?")
+    }
+}
+
 include($$PWD/AuxiliarCustomWidgets/AuxiliarCustomWidgets.pri)
 include($$PWD/aux_widgets/AuxiliarWidgets.pri)
 include($$PWD/big_widgets/BigWidgets.pri)


### PR DESCRIPTION
<!-- Please, before creating the Pull Request ensure that your code is formatted following the clang-format file in the repo. Make sure that the code compiles and you've tested in any way. -->

<!-- Once the Pull Request is open, please mark the checkbox regarding the change type you are submitting. -->

## Description
It's too easy to run into compile errors from a Git clone, and it would be nice to provide help to users that prevents that situation and explains what to do instead.
<!--- Provide a short description of what has been changed and which area does it affect --->

## Change Type

- [ ] Bugfix
- [ ] Feature
- [x] Improvement

## Reason
This will stop QMake from creating a Makefile and will hence stop users from running into compile errors from missing Git submodules, i.e. issue #268.

## Related Issue
#268

## Tests
Delete all Git submodules, run QMake, compare expected output, check fro non-zero return code and lack of Makefile, then bring back Git submodules, and run QMake again, no error and Makefile present
