### PR TITLE
QMake: Fix updating of Git submodules / Fix use of function "system"

### DIFF
--- a/GitQlient.pro
+++ b/GitQlient.pro
@@ -5,7 +5,7 @@ TARGET = gitqlient
 QT += widgets core network gui
 DEFINES += QT_DEPRECATED_WARNINGS
 
-if (!exists(src/git/.git) || !exists(src/AuxiliarCustomWidgets/.git) || !exists(src/QLogger/.git) || !exists(src/QPinnableTabWidget/.git)){
+if (!exists(src/git/.git) || !exists(src/AuxiliarCustomWidgets/.git) || !exists(src/QLogger/.git) || !exists(src/QPinnableTabWidget/.git)) {
     message("Submodule update:")
     system(git submodule update --init --recursive)
 }

--- a/GitQlient.pro
+++ b/GitQlient.pro
@@ -7,7 +7,7 @@ DEFINES += QT_DEPRECATED_WARNINGS
 
 if (!exists(src/git/.git) || !exists(src/AuxiliarCustomWidgets/.git) || !exists(src/QLogger/.git) || !exists(src/QPinnableTabWidget/.git)){
     message("Submodule update:")
-    $$system(git submodule update --init --recursive)
+    system(git submodule update --init --recursive)
 }
 
 unix:!macos {


### PR DESCRIPTION
<!-- Please, before creating the Pull Request ensure that your code is formatted following the clang-format file in the repo. Make sure that the code compiles and you've tested in any way. -->

<!-- Once the Pull Request is open, please mark the checkbox regarding the change type you are submitting. -->

## Description
This address warning `GitQlient.pro:10: Conditional must expand to exactly one word.` and also forwards standard output of the git command to the user.

## Change Type

- [x] Bugfix
- [ ] Feature
- [ ] Improvement

## Reason
Current call to `$$system` is broken, first reported at https://github.com/francescmm/GitQlient/issues/268#issuecomment-1425904947 .

## Related Issue
#268, precisely https://github.com/francescmm/GitQlient/issues/268#issuecomment-1425904947

## Tests
Before the fix:
```
# qmake5 GitQlient.pro ; echo $?
Project MESSAGE: Submodule update:
/home/sping/__playground/gitqlient-fork/GitQlient.pro:10: Conditional must expand to exactly one word.
Project MESSAGE: Found version "1.6.1" at commit "f432ba85".
```

After the fix:
```
# qmake5 GitQlient.pro ; echo $?
Project MESSAGE: Submodule update:
Submodule path 'src/AuxiliarCustomWidgets': checked out 'f86e72abd442f73b1e3b10ac922908d03444f115'
Submodule path 'src/QLogger': checked out 'ce2f35bad6440a14802fed6c043323d4227ef9a9'
Submodule path 'src/QPinnableTabWidget': checked out '40d0a02e5bdf2f49f9ea41ca533093b2808b0140'
Submodule path 'src/git': checked out '638528521b75704708ee65b13d577f0634120897'
Project MESSAGE: Found version "1.6.1" at commit "f432ba85".
```

