### PR TITLE
Fix longLog (Commit Description) output

### DIFF
--- a/src/cache/CommitInfo.cpp
+++ b/src/cache/CommitInfo.cpp
@@ -16,7 +16,7 @@ CommitInfo::CommitInfo(QByteArray data)
    parseDiff(data, 1);
 }
 
-void CommitInfo::parseDiff(QByteArray &data, int startingField)
+void CommitInfo::parseDiff(QByteArray &data, qsizetype startingField)
 {
    if (data.isEmpty())
       return;
@@ -39,9 +39,9 @@ void CommitInfo::parseDiff(QByteArray &data, int startingField)
       committer = fields.at(startingField++);
       author = fields.at(startingField++);
       dateSinceEpoch = std::chrono::seconds(fields.at(startingField++).toInt());
-      shortLog = fields.at(startingField);
+      shortLog = fields.at(startingField++);
 
-      for (auto i = 6; i < fields.count(); ++i)
+      for (auto i = startingField; i < fields.count(); ++i)
          longLog += fields.at(i) + '\n';
 
       longLog = longLog.trimmed();

--- a/src/cache/CommitInfo.h
+++ b/src/cache/CommitInfo.h
@@ -96,5 +96,5 @@ private:
 
    friend class GitCache;
 
-   void parseDiff(QByteArray &data, int startingField);
+   void parseDiff(QByteArray &data, qsizetype startingField);
 };


### PR DESCRIPTION
Currently the 1st line of Commit Description is ommited at least on Commit Info Panel output. It's due to wrong start line number in the loop. The magic number is replaced with current startingField value.

<!-- Please, before creating the Pull Request ensure that your code is formatted following the clang-format file in the repo. Make sure that the code compiles and you've tested in any way. -->

<!-- Once the Pull Request is open, please mark the checkbox regarding the change type you are submitting. -->

## Description
<!--- Provide a short description of what has been changed and which area does it affect --->

## Change Type

- [x] Bugfix
- [ ] Feature
- [ ] Improvement

## Reason
<!--- Provide a reason why this change was made.--->
Before the patch (notice \<No description provided\>):
![before_longLog_patch](https://user-images.githubusercontent.com/18756734/218343770-01172fa6-7e38-41c1-8534-485b081db53a.png)

After the patch (notice actual commit description):
![after_longLog_patch](https://user-images.githubusercontent.com/18756734/218343778-68b65fc6-80a4-430b-b5bd-266caaa95f36.png)

## Related Issue
<!--- Is this Pull Request related with an existing issue on GitQlient? If so, please provide the number starting with # (e.g. #20). --->

## Tests
<!--- How have you tested your change? --->
