### PR TITLE
Fix RepoConfig and Settings tabs GUI Styles colors

### DIFF
--- a/src/aux_widgets/InitialRepoConfig.ui
+++ b/src/aux_widgets/InitialRepoConfig.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>600</width>
-    <height>400</height>
+    <width>640</width>
+    <height>480</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>600</width>
-    <height>400</height>
+    <width>640</width>
+    <height>480</height>
    </size>
   </property>
   <property name="maximumSize">

--- a/src/big_widgets/ConfigWidget.ui
+++ b/src/big_widgets/ConfigWidget.ui
@@ -81,12 +81,6 @@
       <number>0</number>
      </property>
      <widget class="QWidget" name="gitQlientTab">
-      <property name="autoFillBackground">
-       <bool>false</bool>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">background: transparent;</string>
-      </property>
       <attribute name="title">
        <string>GitQlient</string>
       </attribute>
@@ -678,7 +672,7 @@
                   <number>10</number>
                  </property>
                  <item row="0" column="0" colspan="2">
-                  <widget class="QCheckBox" name="chbCredentials">
+                  <widget class="CheckBox" name="chbCredentials">
                    <property name="text">
                     <string>Store credentials using GitQlient (Current session or in Storage)</string>
                    </property>

--- a/src/resources/stylesheet_colors_bright.css
+++ b/src/resources/stylesheet_colors_bright.css
@@ -2,6 +2,11 @@
 /*               QWidgets START              */
 /*********************************************/
 
+QGroupBox
+{
+    color: #D89000;
+}
+
 QToolButton
 {
    background: white;
@@ -184,7 +189,7 @@ QComboBox:editable {
 }
 
 QComboBox:on {
-   background: #2E2F30;
+   background: #606162;
 }
 
 QComboBox QAbstractItemView
@@ -476,6 +481,24 @@ InitScreen
 
 /*********************************************/
 /*            GitQlient class END            */
+/*********************************************/
+
+/*********************************************/
+/*            ConfigWidget START             */
+/*********************************************/
+
+ConfigWidget QTabBar::tab:selected, ConfigWidget QTabWidget QWidget, ConfigWidget QScrollArea QWidget
+{
+   background-color: #F4F5F5;
+}
+
+ConfigWidget FileDiffView, HunkWidget FileDiffView
+{
+   border: 0;
+}
+
+/*********************************************/
+/*             ConfigWidget END              */
 /*********************************************/
 
 /*********************************************/

--- a/src/resources/stylesheet_colors_bright.css
+++ b/src/resources/stylesheet_colors_bright.css
@@ -441,6 +441,11 @@ RepoConfigDlg QPushButton:pressed
    background: #C6C6C7;
 }
 
+InitialRepoConfig QGroupBox
+{
+   background-color: #E6E6E7;
+}
+
 /*********************************************/
 /*             RepoConfigDlg END             */
 /*********************************************/

--- a/src/resources/stylesheet_colors_dark.css
+++ b/src/resources/stylesheet_colors_dark.css
@@ -435,6 +435,11 @@ RepoConfigDlg
    background-color: #2E2F30;
 }
 
+InitialRepoConfig QGroupBox
+{
+   background-color: #404142;
+}
+
 QFrame#tabWidget > QPushButton[selected=true], QFrame#tabWidget > QPushButton[selected=true]:hover
 {
     background-color: #606162;

--- a/src/resources/stylesheet_colors_dark.css
+++ b/src/resources/stylesheet_colors_dark.css
@@ -486,7 +486,7 @@ InitScreen
 /*            ConfigWidget START             */
 /*********************************************/
 
-ConfigWidget QTabBar::tab:selected, ConfigWidget QTabWidget > QWidget, ConfigWidget QScrollArea QWidget
+ConfigWidget QTabBar::tab:selected, ConfigWidget QTabWidget QWidget, ConfigWidget QScrollArea QWidget
 {
    background-color: #2E2F30;
 }


### PR DESCRIPTION
<!-- Please, before creating the Pull Request ensure that your code is formatted following the clang-format file in the repo. Make sure that the code compiles and you've tested in any way. -->

<!-- Once the Pull Request is open, please mark the checkbox regarding the change type you are submitting. -->

## Description
<!--- Provide a short description of what has been changed and which area does it affect --->

This pull request fixes styles issue for dark and bright theme:
* Fix RepoConfig dialog window size and QGroupBox colors;
* Fix CheckBox font color (dark theme);
* Fix QGroupBox background color (dark theme);
* Fix QComboBox background colors (dark and bright themes);
* Fix QGroupBox background colors (brigth theme) for system Breeze Dark theme;

## Change Type

- [x] Bugfix
- [ ] Feature
- [ ] Improvement

## Reason
<!--- Provide a reason why this change was made.--->

The some Styles elements aren't populated in KDE Plasma environment both for dark and bright theme

## Related Issue
<!--- Is this Pull Request related with an existing issue on GitQlient? If so, please provide the number starting with # (e.g. #20). --->

https://github.com/francescmm/GitQlient/issues/262

## Tests
<!--- How have you tested your change? --->

1. RepoConfig Dialog window  

**before patch**
 ![bright_RepoConfig](https://user-images.githubusercontent.com/18756734/218891004-2799b92e-a174-4d34-bb8c-403f4b7bb376.png)
![dark_RepoConfig](https://user-images.githubusercontent.com/18756734/218891617-198abaf7-e498-4458-8bfe-b31d982e306e.png)

**after patch**
![bright_RepoConfig_patched](https://user-images.githubusercontent.com/18756734/218891721-bd7ee7c9-bf10-4583-afb6-cfd13ba9b9a1.png)
![dark_RepoConfig_patched](https://user-images.githubusercontent.com/18756734/218891737-b1bcd297-1825-4763-a3a8-6a177c3d6372.png)

2. GitQlient settings tab (dark theme) : QComboBox

**before patch**
![dark_settings_GitQlient_tab](https://user-images.githubusercontent.com/18756734/218892232-2ad25e49-b5e1-45cc-9e85-0b81fc522e7e.png)

**after patch**
![dark_settings_GitQlient_tab_patched](https://user-images.githubusercontent.com/18756734/218892258-48e02653-189a-4ce0-a935-8c84384b387f.png)

3. GitQlient settings tab (bright theme) : QComboBox

**before patch**
![bright_settings_GitQlient_tab](https://user-images.githubusercontent.com/18756734/218893405-0b460033-8403-41e7-b0c1-100079fc26b8.png)

**after patch**
![bright_settings_GitQlient_tab_patched](https://user-images.githubusercontent.com/18756734/218893415-fd88964c-fe4f-4507-a9dd-3ae8dc1bee39.png)


4. Repository settings tab (dark theme) : QComboBox, CheckBox (font color)

**before patch**
![dark_settings_Repository_tab](https://user-images.githubusercontent.com/18756734/218892586-75cc0997-7cf5-4119-ac58-5748a49cc3cb.png)

**after patch**
![dark_settings_Repository_tab_patched](https://user-images.githubusercontent.com/18756734/218892607-be9d889a-f96b-4157-8efa-01c9939386ff.png)

5. Repository settings tab (brigth) : QComboBox, QGroupBox

**before patch**
![bright_settings_Repository_tab](https://user-images.githubusercontent.com/18756734/218893589-097bb48a-dc94-4453-9393-162606ef529e.png)

**after patch**
![bright_settings_Repository_tab_patched](https://user-images.githubusercontent.com/18756734/218893596-edddaea5-760a-43d5-9c9b-9a1ec04ca508.png)

6. Plugins settings tab (dark theme) : QGroupBox

**before patch**
![dark_settings_Plugins_tab](https://user-images.githubusercontent.com/18756734/218892908-4721cdc3-5720-4e7d-be49-ff30eb478e54.png)

**after patch**
![dark_settings_Plugins_tab_patched](https://user-images.githubusercontent.com/18756734/218892918-4fdfc2e9-9ba8-496d-845f-83083212ab08.png)

7. Shortcuts settings tab (dark theme) : QGroupBox

**before patch**
![dark_settings_Shortcuts_tab](https://user-images.githubusercontent.com/18756734/218893162-d9251d11-4af6-4f66-862a-0621a4225f31.png)

**after patch**
![dark_settings_Shortcuts_tab_patched](https://user-images.githubusercontent.com/18756734/218893172-d800c199-ead4-4a04-9c76-28c99f6b7978.png)
