### PR TITLE
fix: [UI] Improve NewVersionInfoDlg scrolling and layout

### DIFF
--- a/src/aux_widgets/NewVersionInfoDlg.cpp
+++ b/src/aux_widgets/NewVersionInfoDlg.cpp
@@ -2,6 +2,8 @@
 #include "ui_NewVersionInfoDlg.h"
 
 #include <GitQlientSettings.h>
+#include <QScrollArea>
+#include <QLabel>
 
 NewVersionInfoDlg::NewVersionInfoDlg(QWidget *parent)
    : QDialog(parent)
@@ -119,7 +121,12 @@ void NewVersionInfoDlg::goNextPage()
 
 void NewVersionInfoDlg::createAddPage(const QString &title, const QStringList &imgsSrc, const QString &desc)
 {
+   QScrollArea *scrollArea = new QScrollArea();
+   scrollArea->setWidgetResizable(true);
+   scrollArea->setFrameShape(QFrame::NoFrame);
+
    const auto page = new QWidget();
+   scrollArea->setWidget(page);
    const auto titleLabel = new QLabel(title);
    auto font = titleLabel->font();
    font.setPointSize(14);
@@ -128,12 +135,14 @@ void NewVersionInfoDlg::createAddPage(const QString &title, const QStringList &i
    titleLabel->setAlignment(Qt::AlignCenter);
 
    const auto gridLayout = new QVBoxLayout(page);
-   gridLayout->setAlignment(Qt::AlignTop | Qt::AlignHCenter);
+   gridLayout->setAlignment(Qt::AlignTop);
+   gridLayout->addSpacing(30);
    gridLayout->addWidget(titleLabel);
 
    for (const auto &imgSrc : imgsSrc)
    {
       const auto img = new QLabel();
+      img->setAlignment(Qt::AlignCenter);
       img->setPixmap(QPixmap(QString(":/images/NewVersionInfoDlg/%1").arg(imgSrc)));
       gridLayout->addWidget(img);
    }
@@ -143,7 +152,7 @@ void NewVersionInfoDlg::createAddPage(const QString &title, const QStringList &i
    description->setTextFormat(Qt::RichText);
    gridLayout->addWidget(description);
 
-   ui->stackedWidget->addWidget(page);
+   ui->stackedWidget->addWidget(scrollArea);
 }
 
 void NewVersionInfoDlg::saveConfig()

--- a/src/aux_widgets/NewVersionInfoDlg.ui
+++ b/src/aux_widgets/NewVersionInfoDlg.ui
@@ -34,37 +34,6 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QLabel" name="lGitQlientVersion">
-     <property name="font">
-      <font>
-       <pointsize>18</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>5</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
     <widget class="QStackedWidget" name="stackedWidget">
      <property name="currentIndex">
       <number>-1</number>


### PR DESCRIPTION
<!-- Please, before creating the Pull Request ensure that your code is formatted following the clang-format file in the repo. Make sure that the code compiles and you've tested in any way. -->

<!-- Once the Pull Request is open, please mark the checkbox regarding the change type you are submitting. -->

## Description
Add QScrollArea to make content scrollable and improve layout alignment:
- Wrap page content in QScrollArea for better handling of large content
- Fix image alignment to center

## Change Type

- [x] Bugfix
- [ ] Feature
- [ ] Improvement

## Reason
<!--- Provide a reason why this change was made.--->
Too much content is displayed, but the dialog is too small causing incomplete display

## Related Issue
<!--- Is this Pull Request related with an existing issue on GitQlient? If so, please provide the number starting with # (e.g. #20). --->

## Tests
<!--- How have you tested your change? --->
**before patch**
![image](https://github.com/user-attachments/assets/bf35b1d4-bd28-4d7a-b576-1db3576b217e)

**after patch**
![image](https://github.com/user-attachments/assets/5b37877b-8379-4888-958c-7098c1e4e6b8)
![image](https://github.com/user-attachments/assets/3ed83458-16fa-4ee9-9b98-b30c0557800b)