### PR TITLE
Get CI off of about-to-be-removed Ubuntu 20.04

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
     needs: [Tarball]
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     defaults:
       run:


### PR DESCRIPTION
<!-- Please, before creating the Pull Request ensure that your code is formatted following the clang-format file in the repo. Make sure that the code compiles and you've tested in any way. -->

<!-- Once the Pull Request is open, please mark the checkbox regarding the change type you are submitting. -->

## Description
Image `ubuntu-20.04` will stop working on 2025-04-01.

## Change Type

- [ ] Bugfix
- [ ] Feature
- [x] Improvement

## Reason
https://github.com/actions/runner-images/issues/11101

## Related Issue
<!--- Is this Pull Request related with an existing issue on GitQlient? If so, please provide the number starting with # (e.g. #20). --->

## Tests
Nothing needed but a run of CI
